### PR TITLE
feat: add `hasConsent` flag support to thank you script

### DIFF
--- a/src/scripts/vanilla/thankyou-page/thankyou-page-handler.ts
+++ b/src/scripts/vanilla/thankyou-page/thankyou-page-handler.ts
@@ -127,6 +127,7 @@ export class SovendusThankyouPage {
       window.sovIframes.push({
         trafficSourceNumber: voucherNetworkConfig.trafficSourceNumber,
         trafficMediumNumber: voucherNetworkConfig.trafficMediumNumber,
+        hasConsent: sovThankyouConfig.orderData.hasConsent,
         sessionId: sovThankyouConfig.orderData.sessionId,
         orderId: sovThankyouConfig.orderData.orderId,
         orderValue: sovThankyouConfig.orderData.orderValue?.netOrderValue,


### PR DESCRIPTION
According to https://developer-hub.sovendus.com/Voucher-Network-Checkout-Benefits/Web-Integration/Generic-Web-Integration there is an optional hasConsent parameter for the Thank You Page.

This PR adds the flag.

In addition, please check the other PR for this change: https://github.com/Sovendus-GmbH/sovendus-integration-types/pull/2